### PR TITLE
Fix for npm run start command error

### DIFF
--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -70,6 +70,7 @@
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,
+  "starterkitSubDir": "dist",
   "starterkitPostInstallClean": false,
   "outputFileSuffixes": {
     "rendered": ".rendered",

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ The webpack wrapper around [Pattern Lab Node Core](https://github.com/pattern-la
 ## Installation and Starting
 
 1. `yarn install` or `npm install`
-2. `yarn start` or `npm run start`
+2. `yarn start` or `npm run patternlab:serve`
 
 
 ## Packaged Components


### PR DESCRIPTION
When running npm run start, it calls an npm script that then calls
yarn. However, this is supposed to be an npm-only command. This commit
changes the documentation to directly run the patternlab:serve command
instead