### PR TITLE
get hard-coded folders dynamicly from patternlab-config.json

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -16,7 +16,7 @@ module.exports = env => {
   
   const config = merge.smartStrategy(plConfig.webpackMerge)({
     devtool: ifDev('source-map'),
-    context: resolve(__dirname, 'source'),
+    context: resolve(__dirname, plConfig.paths.source.root),
     node: {
       fs: "empty"
     },
@@ -29,7 +29,7 @@ module.exports = env => {
         })
     },
     output: {
-      path: resolve(__dirname, 'public'),
+      path: resolve(__dirname, plConfig.paths.public.root),
       filename: '[name].js'
     },
     plugins:  removeEmpty([


### PR DESCRIPTION
This fixes the issue addressed here: https://github.com/Comcast/patternlab-edition-node-webpack/issues/24

- Remove hard-coded paths from webpack.config.babel.js and pull paths from patternlab-config.js