### PR TITLE
Update glob pattern for watched files in config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -110,8 +110,8 @@ module.exports = env => {
 
               // additional watch files
               const watchFiles = [
-                `${plConfig.paths.source.patterns}**/*.(json|md|yaml|yml)`,
-                `${plConfig.paths.source.data}**/*.(json|md|yaml|yml)`,
+                `${plConfig.paths.source.patterns}**/*.+(json|md|yaml|yml)`,
+                `${plConfig.paths.source.data}**/*.+(json|md|yaml|yml)`,
                 `${plConfig.paths.source.fonts}**/*`,
                 `${plConfig.paths.source.images}**/*`,
                 `${plConfig.paths.source.meta}**/*`,


### PR DESCRIPTION
See [minmatch documentation](https://github.com/isaacs/minimatch#usage). Tested in my existing setup with the Webpack v3 version, fixes rebuilds on changed data files.